### PR TITLE
`oxford` will not add comma in list with 2 items. 

### DIFF
--- a/src/clojure/contrib/humanize.cljc
+++ b/src/clojure/contrib/humanize.cljc
@@ -238,9 +238,11 @@
                                                            (str remaining " " (pluralize-noun remaining "other"))
                                                            (str remaining " other " (pluralize-noun remaining
                                                                                                     truncate-noun)))]
-                                        (str (join (interpose ", " display-coll))
-                                             ", and " last-item))
-
+                                        (if (= 1 maximum-display)
+                                          ; if only one item is displayed there should be no oxford comma
+                                          (str (apply str display-coll) " and " last-item)
+                                          (str (join (interpose ", " display-coll))
+                                               ", and " last-item)))
      ;; TODO: shouldn't reach here, throw exception
       :else coll-length)))
 

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -142,9 +142,9 @@
                      :maximum-display 2)
              (str (items 0) ", "
                   (items 1) ", and " 3 " others")))
-      (is (= (oxford (take 2 items) 
+      (is (= (oxford (take 4 items)
                      :maximum-display 1)
-             (str (items 0) " and " "1 other"))))
+             (str (items 0) " and " 3 " others"))))
 
     (testing "should accept custom trucation strings"
       (let [truncate-noun "fruit"]


### PR DESCRIPTION
fixes #23 
I have added the appropriate tests.

also, when `:maximum-display` is 1 a comma shouldn't be added (since its only two items) => "item1 and others"
I've changed that and added tests for it.