### PR TITLE
convert from using clj-time (ie: joda-time) to java.time

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,19 @@
-{:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
-         org.clojure/math.numeric-tower {:mvn/version "0.0.5"}
-         clj-time/clj-time              {:mvn/version "0.15.2"}
-         com.andrewmcveigh/cljs-time    {:mvn/version "0.5.2"}}
+{:deps  {org.clojure/clojure               {:mvn/version "1.11.1"}
+         org.clojure/math.numeric-tower    {:mvn/version "0.0.5"}
+         com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}}
  :paths ["src"]
  :aliases
  {:test      {:extra-paths ["test"]
               :extra-deps  {io.github.cognitect-labs/test-runner
-                            {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                            {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                            clj-time/clj-time {:mvn/version "0.15.2"}}
               :main-opts   ["-m" "cognitect.test-runner"]
               :exec-fn     cognitect.test-runner.api/test}
   :cljs-test {:extra-paths ["test"]
               :extra-deps  {kongeor/cljs-test-runner
                             {:git/url "https://github.com/kongeor/cljs-test-runner"
-                             :sha     "fa604e9e5f4e74a544958dfdf4c5ccc2a4b2c916"}}
+                             :sha     "fa604e9e5f4e74a544958dfdf4c5ccc2a4b2c916"}
+                            com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}}
               :main-opts   ["-m" "cljs-test-runner.main"]}
   :clj-kondo {:replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
               :main-opts    ["-m" "clj-kondo.main"]}

--- a/src/clojure/contrib/macros.cljc
+++ b/src/clojure/contrib/macros.cljc
@@ -1,9 +1,0 @@
-(ns clojure.contrib.macros
-  (:require [clojure.contrib.inflect :refer [pluralize-noun]]))
-
-(defmacro with-dt-diff [desc-diff diff desc-type future-time? prefix suffix]
-  `(let [d# (~desc-diff ~diff)
-         t# (pluralize-noun (~desc-diff ~diff) ~desc-type)]
-     (if ~future-time?
-       (str ~prefix " " d# " " t#)
-       (str d# " " t# " " ~suffix))))

--- a/src/clojure/contrib/util/time_convert.cljc
+++ b/src/clojure/contrib/util/time_convert.cljc
@@ -1,0 +1,77 @@
+(ns clojure.contrib.util.time-convert
+  (:require
+    [cljc.java-time.extn.predicates :as jt.predicates]
+    [cljc.java-time.format.date-time-formatter :as dt.formats]
+    [cljc.java-time.local-date-time :as jt.ldt]))
+
+(def joda-time-present?
+  (try
+    (import '(org.joda.time DateTime Instant))
+    true
+    (catch Exception _ false)))
+
+(defn joda-time-date-time? [dt]
+  (and joda-time-present?
+       (instance? org.joda.time.DateTime dt)))
+
+(defn joda-time-instant? [i]
+  (and joda-time-present?
+       (instance? org.joda.time.Instant i)))
+
+(defn java-util-date? [d]
+  (instance? java.util.Date d))
+
+(def java-util-date-iso8601-formatter
+  (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss"))
+
+(defn java-util-date->iso8601-str
+  ^String
+  [^java.util.Date date]
+  (.format java-util-date-iso8601-formatter date))
+
+(defn java-time-local-date->iso8601-str
+  ^String
+  [^java.time.LocalDate date]
+  (str (.toString date) "T00:00:00"))
+
+(defn looks-like-an-iso8601-string?
+  [s]
+  (and (string? s)
+       (boolean (re-matches #"^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$" s))))
+
+(defn looks-like-a-date-string?
+  [s]
+  (and (string? s)
+       (boolean (re-matches #"^\d\d\d\d-\d\d-\d\d$" s))))
+
+(defn coerce-to-local-date-time
+  "Does it's best to convert t into a java.time.LocalDateTime object.
+  Accepts:
+  - java.time.LocalDateTime and java.time.LocalDate
+  - org.joda.time.DateTime and org.joda.time.Instant (if the JodaTime library is present)
+  - java.util.Date
+  - Strings in 'yyyy-MM-dd' and 'yyyy-MM-ddTHH:MM:SS' formats
+
+  Throws an Exception if unable to convert."
+  [t]
+  (cond
+    ;; t is already a java.time.LocalDateTime
+    (jt.predicates/local-date-time? t) t
+
+    ;; java.time.LocalDate
+    (jt.predicates/local-date? t) (jt.ldt/parse (java-time-local-date->iso8601-str t) dt.formats/iso-date-time)
+
+    ;; joda-time types
+    (or (joda-time-date-time? t)
+        (joda-time-instant? t))
+    (jt.ldt/parse (.toString t) dt.formats/iso-date-time)
+
+    ;; java.util.Date
+    (java-util-date? t) (jt.ldt/parse (java-util-date->iso8601-str t) dt.formats/iso-date-time)
+
+    ;; Strings
+    (looks-like-an-iso8601-string? t) (jt.ldt/parse t dt.formats/iso-date-time)
+    (looks-like-a-date-string? t) (jt.ldt/parse (str t "T00:00:00") dt.formats/iso-date-time)
+
+    ;; ¯\_(ツ)_/¯
+    :else (throw (Exception. "Unable to coerce to java.time.LocalDateTime"))))

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -242,10 +242,10 @@
              (datetime (jt.ldt/minus-minutes t1 10)
                        :suffix "in the glorious past"
                        :now-dt t1)))
-      (is (= "forward, into our glorious future 1 year"
+      (is (= "forward, into our bright future 1 year"
              (datetime (jt.ldt/plus-years t1 1)
                        :now-dt t1
-                       :prefix "forward, into our glorious future")))
+                       :prefix "forward, into our bright future")))
       (is (= "in 1 year"
              (datetime (jt.ldt/plus-years t1 1)
                        :now-dt t1

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -1,20 +1,15 @@
 (ns clojure.contrib.humanize-test
-  (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest testing is are]])
+  (:require #?(:clj  [clojure.test :refer [are deftest is testing]]
+               :cljs [cljs.test :refer-macros [are deftest is testing]])
             [clojure.contrib.humanize :refer [intcomma ordinal intword numberword
-                                              filesize truncate oxford datetime
-                                              duration]
+                                              filesize truncate oxford datetime duration]
              :as h]
             [clojure.contrib.inflect :refer [pluralize-noun]]
-            #?(:clj [clojure.math.numeric-tower :refer [expt]])
-            #?(:clj  [clj-time.core  :refer [now from-now seconds millis minutes
-                                             hours days weeks months years plus]]
-               :cljs [cljs-time.core :refer [now from-now seconds millis minutes
-                                             hours days weeks months years plus]])
-            #?(:clj  [clj-time.local  :refer [local-now]]
-               :cljs [cljs-time.local :refer [local-now]])
-            #?(:clj  [clj-time.coerce  :refer [to-date-time to-string]]
-               :cljs [cljs-time.coerce :refer [to-date-time to-string]])))
+            [cljc.java-time.local-date-time :as jt.ldt]
+            ;; NOTE: clj-time is included here for testing purposes, but not in the humanize library
+            #?(:clj  [clj-time.core :as clj-time]
+               :cljs [cljs-time.core :as clj-time])
+            #?(:clj [clojure.math.numeric-tower :refer [expt]])))
 
 #?(:cljs (def ^:private expt (.-pow js/Math)))
 
@@ -50,13 +45,13 @@
                                      [3500000000000000000000 "3.5 sextillion"]
                                      [8100000000000000000000000000000000 "8.1 decillion"]
                                      [1230000 "1.23 million" "%.2f"]
-                                     [(expt 10 101) "10.0 googol"]
-                                     ]]
+                                     [(expt 10 101) "10.0 googol"]]]
+
       ;; default argument
       (let [format (if (nil? format) "%.1f" format)]
         (is (= (intword testnum
-                        :format format
-                        )
+                        :format format)
+
                result))))))
 
 (deftest numberword-test
@@ -90,29 +85,29 @@
                                              [3000, "2.9KiB", true]
                                              [3000000, "2.9MiB", true]
                                              [(* (expt 10 26) 30), "3000.0YB"]
-                                             [(* (expt 10 26) 30), "2481.5YiB", true]
+                                             [(* (expt 10 26) 30), "2481.5YiB", true]]]
 
-                                             ]]
+
       ;; default argument
       (let [binary (boolean binary)
             format (if (nil? format) "%.1f" format)]
         (is (= (filesize testsize
                          :binary binary
-                         :format format
-                         )
+                         :format format)
+
                result))))))
 
 (deftest truncate-test
-  (testing "truncate should not return a string larger than give length."
-    (let [string "asdfghjkl" ]
+  (testing "truncate should not return a string larger than the given length."
+    (let [string "asdfghjkl"]
       (is (= (count (truncate string 7)) 7))
       (is (= (count (truncate string 7 "1234")) 7))
       (is (= (count (truncate string 100)) (count string)))))
 
   (testing "testing truncate with expected data."
     (let [string "abcdefghijklmnopqrstuvwxyz"]
-      (is (= (truncate string 14) "abcdefghijk..."))
-      (is (= (truncate string 14 "...kidding") "abcd...kidding")))))
+      (is (= (truncate string 14) "abcdefghijklm…"))
+      (is (= (truncate string 14 "…kidding") "abcdef…kidding")))))
 
 (deftest oxford-test
   (let [items ["apple", "orange", "banana", "pear", "pineapple", "strawberry"]]
@@ -158,54 +153,104 @@
             (str (items 0) ", "
                  (items 1) ", and " (items 2)))))))
 
+(def one-decade-in-years 10)
+(def one-century-in-years 100)
+(def one-millenia-in-years 1000)
+
+(def datetime-test-phrases
+  [["a moment ago" identity]
+   ["a moment ago" #(jt.ldt/minus-nanos % 1000)]
+   ["in a moment"  #(jt.ldt/plus-nanos % 1000)]
+
+   ["10 seconds ago" #(jt.ldt/minus-seconds % 10)]
+   ["1 second ago"   #(jt.ldt/minus-seconds % 1)]
+   ["in 10 seconds"  #(jt.ldt/plus-seconds % 10)]
+   ["in 1 second"    #(jt.ldt/plus-seconds % 1)]
+
+   ["10 minutes ago" #(jt.ldt/minus-minutes % 10)]
+   ["in 10 minutes"  #(jt.ldt/plus-minutes % 10)]
+   ["1 minute ago"   #(jt.ldt/minus-minutes % 1)]
+   ["in 1 minute"    #(jt.ldt/plus-minutes % 1)]
+
+   ["10 hours ago" #(jt.ldt/minus-hours % 10)]
+   ["in 10 hours"  #(jt.ldt/plus-hours % 10)]
+   ["1 hour ago"   #(jt.ldt/minus-hours % 1)]
+   ["in 1 hour"    #(jt.ldt/plus-hours % 1)]
+
+   ["5 days ago" #(jt.ldt/minus-days % 5)]
+   ["in 5 days"  #(jt.ldt/plus-days % 5)]
+   ["1 day ago"  #(jt.ldt/minus-days % 1)]
+   ["in 1 day"   #(jt.ldt/plus-days % 1)]
+
+   ["3 weeks ago" #(jt.ldt/minus-weeks % 3)]
+   ["in 3 weeks"  #(jt.ldt/plus-weeks % 3)]
+   ["1 week ago"  #(jt.ldt/minus-weeks % 1)]
+   ["in 1 week"   #(jt.ldt/plus-weeks % 1)]
+
+   ["2 months ago"  #(jt.ldt/minus-months % 2)]
+   ["in 2 months"   #(jt.ldt/plus-months % 2)]
+   ["10 months ago" #(jt.ldt/minus-months % 10)]
+   ["in 10 months"  #(jt.ldt/plus-months % 10)]
+   ["1 month ago"   #(jt.ldt/minus-months % 1)]
+   ["in 1 month"    #(jt.ldt/plus-months % 1)]
+
+   ["3 years ago" #(jt.ldt/minus-years % 3)]
+   ["in 3 years"  #(jt.ldt/plus-years % 3)]
+   ["1 year ago"  #(jt.ldt/minus-years % 1)]
+   ["in 1 year"   #(jt.ldt/plus-years % 1)]
+
+   ["3 decades ago" #(jt.ldt/minus-years % (* 3 one-decade-in-years))]
+   ["in 3 decades"  #(jt.ldt/plus-years % (* 3 one-decade-in-years))]
+   ["1 decade ago"  #(jt.ldt/minus-years % one-decade-in-years)]
+   ["in 1 decade"   #(jt.ldt/plus-years % one-decade-in-years)]
+
+   ["3 centuries ago" #(jt.ldt/minus-years % (* 3 one-century-in-years))]
+   ["in 3 centuries"  #(jt.ldt/plus-years % (* 3 one-century-in-years))]
+   ["1 century ago"   #(jt.ldt/minus-years % one-century-in-years)]
+   ["in 1 century"    #(jt.ldt/plus-years % one-century-in-years)]
+
+   ["3 millennia ago" #(jt.ldt/minus-years % (* 3 one-millenia-in-years))]
+   ["in 3 millennia"  #(jt.ldt/plus-years % (* 3 one-millenia-in-years))]
+   ["1 millenium ago" #(jt.ldt/minus-years % one-millenia-in-years)]
+   ["in 1 millenium"  #(jt.ldt/plus-years % one-millenia-in-years)]])
+
 (deftest datetime-test
-  (let [past (fn [n unit] (datetime (now) :now-dt (-> n unit from-now)))
-        future (fn [n unit] (datetime (plus (-> n unit from-now) (millis 300)) ; fix delayed execution by adding some millis
-                                      :now-dt (now)))]
-    (testing "date diff to text"
-      (are [expected diff] (= expected diff)
-                           "a moment ago" (datetime (now))
-                           "in a moment" (datetime (-> 500 millis from-now))
-                           "10 seconds ago" (past 10 seconds)
-                           "in 10 seconds" (future 10 seconds)
-                           "1 second ago" (past 1 seconds)
-                           "in 1 second" (future 1 seconds)
-                           "10 minutes ago" (past 10 minutes)
-                           "in 10 minutes" (future 10 minutes)
-                           "1 minute ago" (past 1 minutes)
-                           "in 1 minute" (future 1 minutes)
-                           "10 hours ago" (past 10 hours)
-                           "in 10 hours" (future 10 hours)
-                           "1 hour ago" (past 1 hours)
-                           "in 1 hour" (future 1 hours)
-                           "5 days ago" (past 5 days)
-                           "in 5 days" (future 5 days)
-                           "1 day ago" (past 1 days)
-                           "in 1 day" (future 1 days)
-                           "1 week ago" (past 1 weeks)
-                           "in 1 week" (future 1 weeks)
-                           "3 weeks ago" (past 3 weeks)
-                           "in 3 weeks" (future 3 weeks)
-                           "2 months ago" (past 10 weeks)
-                           "in 2 months" (future 10 weeks)
-                           "10 months ago" (past 10 months)
-                           "in 10 months" (future 10 months)
-                           "1 month ago" (past 1 months)
-                           "in 1 month" (future 1 months)
-                           "3 years ago" (past 3 years)
-                           "in 3 years" (future 3 years)
-                           "1 year ago" (past 1 years)
-                           "in 1 year" (future 1 years)
-                           "3 decades ago" (past 30 years)
-                           "in 3 decades" (future 30 years)
-                           "1 decade ago" (past 10 years)
-                           "in 1 decade" (future 10 years)
-                           "3 centuries ago" (past (* 3 100) years)
-                           "in 3 centuries" (future (* 3 100) years)
-                           "3 millennia ago" (past (* 3 1000) years)
-                           "1 millenium ago" (past 1000 years)
-                           "in 3 millennia" (future (* 3 1000) years)
-                           "in 1 millenium" (future 1000 years)))))
+  (let [t1-str "2022-01-01T01:00:00"
+        t1 (jt.ldt/parse t1-str)]
+    (is (= "a moment ago"
+           (datetime (jt.ldt/now)))
+        ":now-dt is optional")
+    (testing "datetime accepts joda-time values"
+      (is (= "a moment ago"
+             (datetime (clj-time/now)
+                       :now-dt (clj-time/now))))
+      (is (= "10 minutes ago"
+             (datetime (clj-time/minus (clj-time/now) (clj-time/minutes 10))
+                       :now-dt (clj-time/now)))))
+    (testing "test phrases"
+      (doseq [[phrase time-shift-fn] datetime-test-phrases]
+        (is (= phrase
+               (datetime (time-shift-fn t1)
+                         :now-dt t1)))))
+    (testing "suffix and prefix"
+      (is (= "10 minutes ago"
+             (datetime (jt.ldt/minus-minutes t1 10)
+                       :prefix "foo"
+                       :now-dt t1))
+          "prefix for a time in the past does nothing")
+      (is (= "10 minutes in the glorious past"
+             (datetime (jt.ldt/minus-minutes t1 10)
+                       :suffix "in the glorious past"
+                       :now-dt t1)))
+      (is (= "forward, into our glorious future 1 year"
+             (datetime (jt.ldt/plus-years t1 1)
+                       :now-dt t1
+                       :prefix "forward, into our glorious future")))
+      (is (= "in 1 year"
+             (datetime (jt.ldt/plus-years t1 1)
+                       :now-dt t1
+                       :suffix "foo"))
+          "suffix for a time in the past does nothing"))))
 
 (deftest durations
   (testing "duration to terms"

--- a/test/clojure/contrib/inflect_test.cljc
+++ b/test/clojure/contrib/inflect_test.cljc
@@ -1,6 +1,6 @@
 (ns clojure.contrib.inflect-test
-  (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest testing is are]])
+  (:require #?(:clj  [clojure.test :refer [are deftest is testing]]
+               :cljs [cljs.test :refer-macros [are deftest is testing]])
             [clojure.contrib.inflect :refer [pluralize-noun]]))
 
 (deftest pluralize-noun-test

--- a/test/clojure/contrib/util/time_convert_test.cljc
+++ b/test/clojure/contrib/util/time_convert_test.cljc
@@ -1,0 +1,33 @@
+(ns clojure.contrib.util.time-convert-test
+  (:require
+    #?(:clj  [clojure.test :refer [deftest is]]
+       :cljs [cljs.test :refer-macros [deftest is]])
+    [cljc.java-time.extn.predicates :as jt.predicates]
+    [cljc.java-time.local-date :as jt.ld]
+    [cljc.java-time.local-date-time :as jt.ldt]
+    [clojure.contrib.util.time-convert :as tc]
+    ;; NOTE: clj-time is included here for testing purposes, but not in the humanize library
+    #?(:clj  [clj-time.core :as clj-time]
+       :cljs [cljs-time.core :as clj-time]))
+  (:import
+    (org.joda.time Instant)))
+
+(deftest coerce-to-local-date-time-test
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time (jt.ldt/now))))
+      "java.time.LocalDateTime --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time (jt.ld/now))))
+      "java.time.LocalDate --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time (clj-time/now))))
+      "org.joda.time.DateTime --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time (Instant.))))
+      "org.joda.time.Instant --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time (java.util.Date.))))
+      "java.util.Date --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time "2022-01-01T13:45:30")))
+      "iso8601 String --> java.time.LocalDateTime")
+  (is (true? (jt.predicates/local-date-time? (tc/coerce-to-local-date-time "2022-01-01")))
+      "date String --> java.time.LocalDateTime")
+  (is (thrown? Exception (tc/coerce-to-local-date-time "banana")))
+  (is (thrown? Exception (tc/coerce-to-local-date-time {})))
+  (is (thrown? Exception (tc/coerce-to-local-date-time true)))
+  (is (thrown? Exception (tc/coerce-to-local-date-time nil))))


### PR DESCRIPTION
[re: Clojurians Slack](https://clojurians.slack.com/archives/CE1A21MPF/p1677520961228739?thread_ts=1677360499.838999&cid=CE1A21MPF) from @seancorfield:

> Also clj-time has been deprecated for a long time. Myself and the other maintainers have been trying to "encourage" everyone to move off to either Java Time directly or something like cljc.java-time which is portable across ClojureScript and Clojure.

<hr>

- converts the `datetime` function to accept `java.time` objects
- use ellipsis character `…` in the truncate function instead of three periods

Apologies for the large diff here. Parinfer automatically adjusted a lot of indentation in the files.

### TODO

- [ ] check that this works in ClojureScript