### PR TITLE
Remove org.clojure/math.numeric-tower dependency and use clojure.math instead

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,4 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
-         org.clojure/math.numeric-tower {:mvn/version "0.0.5"}
          clj-time/clj-time              {:mvn/version "0.15.2"}
          com.andrewmcveigh/cljs-time    {:mvn/version "0.5.2"}}
  :paths ["src"]

--- a/src/clj_commons/humanize.cljc
+++ b/src/clj_commons/humanize.cljc
@@ -1,6 +1,6 @@
 (ns clj-commons.humanize
   (:refer-clojure :exclude [abs])
-  (:require #?(:clj  [clojure.math.numeric-tower :refer [expt floor round abs]])
+  (:require #?(:clj [clojure.math :as math :refer [floor round log log10]])
             [clj-commons.humanize.inflect :refer [pluralize-noun in?]]
             [clojure.string :as string :refer [join]]
             #?(:clj  [clj-commons.humanize.macros :refer [with-dt-diff]])
@@ -21,18 +21,18 @@
 #?(:clj  (def ^:private num-format format)
    :cljs (def ^:private num-format #(gstring/format %1 %2)))
 
+#?(:clj (def ^:private expt math/pow))
 #?(:cljs (def ^:private expt (.-pow js/Math)))
 #?(:cljs (def ^:private floor (.-floor js/Math)))
 #?(:cljs (def ^:private round (.-round js/Math)))
+#?(:clj (def ^:private abs clojure.core/abs))
 #?(:cljs (def ^:private abs (.-abs js/Math)))
 
-#?(:clj  (def ^:private log #(java.lang.Math/log %))
-   :cljs (def ^:private log (.-log js/Math)))
+#?(:cljs (def ^:private log (.-log js/Math)))
 
 #?(:cljs (def ^:private rounding-const 1000000))
 
-#?(:clj  (def ^:private log10 #(java.lang.Math/log10 %))
-   :cljs (def ^:private log10 (or (.-log10 js/Math)                   ;; prefer native implementation
+#?(:cljs (def ^:private log10 (or (.-log10 js/Math)                   ;; prefer native implementation
                         #(/ (.round js/Math
                                     (* rounding-const
                                        (/ (.log js/Math %)

--- a/test/clj_commons/humanize_test.cljc
+++ b/test/clj_commons/humanize_test.cljc
@@ -6,7 +6,7 @@
                                               duration]
              :as h]
             [clj-commons.humanize.inflect :refer [pluralize-noun]]
-            #?(:clj [clojure.math.numeric-tower :refer [expt]])
+            #?(:clj [clojure.math :as math])
             #?(:clj  [clj-time.core  :refer [now from-now seconds millis minutes
                                              hours days weeks months years plus]]
                :cljs [cljs-time.core :refer [now from-now seconds millis minutes
@@ -16,7 +16,8 @@
             #?(:clj  [clj-time.coerce  :refer [to-date-time to-string]]
                :cljs [cljs-time.coerce :refer [to-date-time to-string]])))
 
-#?(:cljs (def ^:private expt (.-pow js/Math)))
+#?(:clj (def ^:private expt math/pow)
+   :cljs (def ^:private expt (.-pow js/Math)))
 
 (deftest intcomma-test
   (testing "Testing intcomma function with expected data."


### PR DESCRIPTION
This PR helps with babashka compatibility by getting rid of `org.clojure/math.numeric-tower`. The reliance on `clojure.math` means that Clojure 1.11 will be required, but this seems to be the case already.