### PR TITLE
import deps for ClojureScript

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps  {org.clojure/clojure               {:mvn/version "1.11.1"}
          clj-time/clj-time                 {:mvn/version "0.15.2"}
-         com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}}
+         com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}
+         henryw374/js-joda                 {:mvn/version "3.2.0-0"}}
  :paths ["src"]
  :aliases
  ;; clj -X:test

--- a/src/clj_commons/humanize.cljc
+++ b/src/clj_commons/humanize.cljc
@@ -2,12 +2,10 @@
   (:refer-clojure :exclude [abs])
   (:require #?(:clj [clojure.math :as math :refer [floor round log log10]])
             [clj-commons.humanize.inflect :refer [pluralize-noun in?]]
-            [clojure.string :as string :refer [join]]
-            #?@(:clj [[cljc.java-time.duration :as jt.duration]
-                      [cljc.java-time.local-date-time :as jt.ldt]]
-                :cljs [[cljs.java-time.duration :as jt.duration]
-                       [cljs.java-time.local-date-time :as jt.ldt]])
             [clj-commons.humanize.time-convert :refer [coerce-to-local-date-time]]
+            [cljc.java-time.duration :as jt.duration]
+            [cljc.java-time.local-date-time :as jt.ldt]
+            [clojure.string :as string :refer [join]]
             #?@(:cljs [[goog.string :as gstring]
                        [goog.string.format]])))
 
@@ -16,6 +14,7 @@
 
 #?(:clj (def ^:private expt math/pow)
    :cljs (def ^:private expt (.-pow js/Math)))
+
 #?(:cljs (def ^:private floor (.-floor js/Math)))
 #?(:cljs (def ^:private round (.-round js/Math)))
 #?(:clj (def ^:private abs clojure.core/abs)

--- a/test/clj_commons/humanize_test.cljc
+++ b/test/clj_commons/humanize_test.cljc
@@ -5,9 +5,8 @@
                                           filesize truncate oxford datetime
                                           duration]
              :as h]
-            #?@(:clj [[clojure.math :as math]
-                      [cljc.java-time.local-date-time :as jt.ldt]])
-            #?(:cljs [cljs.java-time.local-date-time :as jt.ldt])))
+            #?@(:clj [[clojure.math :as math]])
+            [cljc.java-time.local-date-time :as jt.ldt]))
 
 #?(:clj  (def ^:private expt math/pow)
    :cljs (def ^:private expt (.-pow js/Math)))


### PR DESCRIPTION
This seems to import the correct dependencies for ClojureScript.

Unfortunately, there are some [test failures with the `clj-commons.humanize/filesize` function](https://gist.github.com/oakmac/957e65b07d3f3820b9c8380be8c36626), likely due to math differences between the JVM and JS platforms.

The Google Closure Library includes [some methods](https://github.com/google/closure-library/blob/master/closure/goog/format/format.js#L25) for formatting bytes to human-readable Strings. I wonder if the path of least resistance would be using those for the `:cljs` implementation in this library?

Another point of consideration for ClojureScript is the inclusion of [`cljc.java-time`](https://github.com/henryw374/cljc.java-time) as a dependency. That library uses the [js-joda time library](https://github.com/js-joda/js-joda) under the hood, which increases the build size of the JavaScript output a nontrivial amount (more details [here](https://github.com/juxt/tick/blob/master/docs/cljs.adoc) and [here](https://clojureverse.org/t/cljc-java-time-will-drop-all-npm-foreign-lib-dependencies/6208/5?u=henry_w)). This is not necessarily a deal-breaker for making this library `.cljc`, but it may defer some ClojureScript users who are sensitive to that bundle size increase.