### PR TITLE
fix reported difference in datetime when passed in a date in the future (addresses #44)

### DIFF
--- a/src/clj_commons/humanize/time_convert.cljc
+++ b/src/clj_commons/humanize/time_convert.cljc
@@ -3,6 +3,7 @@
   "Internal utility to convert strings and other typs into LocalDateTime "
   (:require [cljc.java-time.extn.predicates :as jt.predicates]
             [cljc.java-time.format.date-time-formatter :as dt.formats]
+            [cljc.java-time.local-date :as jt.ld]
             [cljc.java-time.local-date-time :as jt.ldt]
             [cljc.java-time.instant :as jt.i]
             [cljc.java-time.zone-id :as jt.zi]
@@ -38,7 +39,10 @@
                (jvm/java-util-date? t)
                (jt.ldt/parse (jvm/java-util-date->iso8601-str t) dt.formats/iso-date-time)]
         :cljs [(instance? js/Date t)
-               (jt.ldt/of-instant (jt.i/of-epoch-milli (.getTime t)) (jt.zi/system-default))])
+               (jt.ldt/of-instant (jt.i/of-epoch-milli (.getTime t)) (jt.zi/system-default))
+
+               (jt.predicates/local-date? t)
+               (jt.ld/at-start-of-day t)])
 
     ;; Strings
     (looks-like-an-iso8601-string? t)

--- a/test/clj_commons/humanize_test.cljc
+++ b/test/clj_commons/humanize_test.cljc
@@ -6,6 +6,7 @@
                                           duration]
              :as h]
             [clojure.math :as math]
+            [cljc.java-time.local-date :as jt.ld]
             [cljc.java-time.local-date-time :as jt.ldt]))
 
 (def ^:private expt math/pow)
@@ -216,7 +217,8 @@
 
 (deftest datetime-test
   (let [t1-str "2022-01-01T01:00:00"
-        t1     (jt.ldt/parse t1-str)]
+        t1     (jt.ldt/parse t1-str)
+        ld-now (jt.ld/now)]
     (is (= "a moment ago"
           (datetime (jt.ldt/now)))
       ":now-dt is optional")
@@ -256,7 +258,20 @@
             (datetime (jt.ldt/plus-years t1 1)
               :now-dt t1
               :suffix "foo"))
-        "suffix for a time in the past does nothing"))))
+          "suffix for a time in the past does nothing"))
+    (testing "datetime handles date arguments intuitively and without being affected by the specific time now"
+      (is (= "today"
+             (datetime (jt.ld/now)))
+          "LocalDate/now is today")
+      (is (and (= "in 1 day"
+                  (datetime (jt.ld/plus-days ld-now 1)))
+               (= "1 day ago"
+                  (datetime (jt.ld/minus-days ld-now 1)))
+               (= "in 3 days"
+                  (datetime (jt.ld/plus-days ld-now 3)))
+               (= "3 days ago"
+                  (datetime (jt.ld/minus-days ld-now 3))))
+          "equidistant dates in the future vs past are accounted for in the same way"))))
 
 (deftest durations
   (testing "duration to terms"

--- a/test/clj_commons/humanize_test.cljc
+++ b/test/clj_commons/humanize_test.cljc
@@ -261,8 +261,12 @@
           "suffix for a time in the past does nothing"))
     (testing "datetime handles date arguments intuitively and without being affected by the specific time now"
       (is (= "today"
-             (datetime (jt.ld/now)))
+             (datetime ld-now))
           "LocalDate/now is today")
+      (is (= "today"
+             (datetime ld-now
+                       :now-dt (jt.ldt/now)))
+          "has no problems with ldt :now-dt arguments")
       (is (and (= "in 1 day"
                   (datetime (jt.ld/plus-days ld-now 1)))
                (= "1 day ago"

--- a/test/clj_commons/humanize_test.cljc
+++ b/test/clj_commons/humanize_test.cljc
@@ -264,7 +264,7 @@
     (testing "datetime handles date arguments intuitively and without being affected by the specific time now"
       (is (= "today"
              (datetime ld-now))
-          "LocalDate/now is today")
+          "today's date returns \"today\"")
       (is (= "today"
              (datetime ld-now
                        :now-dt (jt.ldt/now)))


### PR DESCRIPTION
Addresses #44

I considered a couple of approaches, ranging from adding the current time (and then with a +1 second; good grief! just in order to be able to bump it up at the nanosecond-level to just past 24 hours) to `then-dt` using [atTime](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html#atTime-java.time.OffsetTime-), to maybe doing something with the `cond` if passed in a date; but ultimately settled on this one as the most elegant.

A couple of notes:
- ~~I must apologize for not adding in tests for this just yet; I can take a look at this in time to come (but would also be fine getting help for this)~~ DONE
- I decided to make `(datetime (java.time.LocalDate/now))` equal `"today"` (rather than "a moment ago"); I think that makes sense